### PR TITLE
Default subcommand if no one specified

### DIFF
--- a/komandr.py
+++ b/komandr.py
@@ -7,7 +7,7 @@ import sys
 import inspect
 import argparse
 from functools import wraps
-from itertools import izip_longest
+from itertools import izip_longest, chain
 
 
 class prog(object):
@@ -104,7 +104,11 @@ class prog(object):
         """
         if getattr(self, 'default_subcommand', None):
             subcommand = arg_list[0] if arg_list else ''
-            if not (subcommand and subcommand in self.subparsers.choices):
+            action_option_strings = chain.from_iterable(i.option_strings
+                    for i in self.parser._actions)
+            if not (subcommand
+                    and subcommand in self.subparsers.choices
+                    or subcommand in action_option_strings):
                 arg_list[:0] = [self.default_subcommand]
 
         arg_map = self.parser.parse_args(arg_list).__dict__

--- a/tests.py
+++ b/tests.py
@@ -1,9 +1,13 @@
 # TODO: Add much more tests
 import unittest
 import komandr
+from mock import patch
 
 
 class TestKomandr(unittest.TestCase):
+
+    def tearDown(self):
+        komandr.main.default_subcommand = None
 
     def testCommand(self):
         def foo(bar, baz=None):
@@ -37,6 +41,20 @@ class TestKomandr(unittest.TestCase):
         komandr.main.default_subcommand = 'foo'
         self.assertEqual('bar', komandr.execute([]))
 
+    def testOptionsNotTriggerDefaultSubcommand(self):
+        def foo(baz='bar'):
+            return baz
+        komandr.command(foo)
+
+        komandr.main.default_subcommand = 'foo'
+        with patch.object(komandr.main.parser, 'print_help') as mock:
+            with self.assertRaises(SystemExit) as ex:
+                komandr.execute(['--help'])
+
+        self.assertEqual(0, ex.exception.code)
+        self.assertTrue(mock.called)
+
+        self.assertEqual('bar baz', komandr.execute(['--baz', 'bar baz']))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I would like go write some script without subcommand like this:

``` python
def run(args):
    print args.foo

if __name__ == '__main__':
    parser = argparse.ArgumentParser()
    parser.add_argument('-f', '--foo', help='bar', default='baz')
    args = parser.parse_args()
    run(args)
```

So that I can just simply run `./script.py`.

But I found it's hard to achieve this using `komandr`. Because `self.parser.add_subparsers()` in the constructor make the subcommand a must. So I did a little hack to make the script work like this:

``` python
@komandr.arg('foo', '-f', '--foo', help='baz')
@komandr.command
def run(foo='bar'):
    print foo

if __name__ == __main__:
    komandr.main(default_subcommand='run')
```

The specified default subcommand would be called unless the first argument was `--help` or `--version` or other options which registed to the parser at first.

`komandr` is cool and I hope this a little hack would help to make it better. 

Cheers
