### PR TITLE
Add arg_list to the __call__ method of prog class.

### DIFF
--- a/komandr.py
+++ b/komandr.py
@@ -106,12 +106,15 @@ class prog(object):
         command = arg_map.pop(self._COMMAND_FLAG)
         return command(**arg_map)
 
-    def __call__(self):
+    def __call__(self, arg_list):
         """Calls :py:func:``execute`` with :py:class:``sys.argv`` excluding
         script name which comes first.
 
         """
-        self.execute(sys.argv[1:])
+        if arg_list is not None:  # Can be an empty list
+            return self.execute(arg_list)
+        else:
+            return self.execute(sys.argv[1:])
 
 main = prog()
 arg = main.arg

--- a/tests.py
+++ b/tests.py
@@ -12,6 +12,14 @@ class TestKomandr(unittest.TestCase):
         self.assertEqual(('1', '2'),
                          komandr.execute(['foo', '1', '--baz', '2']))
 
+    def testCustomArgsTobeParsed(self):
+        _newParser = komandr.prog()
+        def foo(bar, baz=None):
+            return bar, baz
+        _newParser.command(foo)
+        self.assertEqual(('1', '2'),
+                         _newParser(['foo', '1', '--baz', '2']))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pullrequest adds the ability to pass an `arg_list` do the `__call__()` method. This is just for convenience, as we can directly call the `execute()` method which already optionally receives an `arg_list`
